### PR TITLE
(#6) expose more useful facts

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -62,16 +62,16 @@ func Run() {
 
 	go interrupWatcher(cancel)
 
-	err = configureManagement()
-	if err != nil {
-		kingpin.Fatalf("Could not configure management: %s", err)
-	}
-
 	switch cmd {
 	case p.FullCommand():
 		poll()
 	case r.FullCommand():
 		receive()
+	}
+
+	err = configureManagement()
+	if err != nil {
+		kingpin.Fatalf("Could not configure management: %s", err)
 	}
 
 	wg.Wait()

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 354fe53a52f61f17446f312d8b110c5a44f62cef6b1ce89cfeb4d222705d9fdf
-updated: 2018-02-12T15:32:45.371541+01:00
+hash: c9e3fbddac4a20f59c46e56c1eea276e6c3c0e20afe1d5e8bb77b9dc93a66903
+updated: 2018-02-12T18:47:50.424986+01:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -14,9 +14,25 @@ imports:
 - name: github.com/choria-io/go-choria
   version: 294656073efe1103bcd8e30d1156347d2177e184
   subpackages:
+  - agents/choriautil
+  - agents/discovery
+  - agents/provision
+  - agents/rpcutil
   - backoff
   - build
   - choria
+  - mcorpc
+  - mcorpc/audit
+  - registration
+  - server
+  - server/agents
+  - server/data
+  - server/discovery
+  - server/discovery/agents
+  - server/discovery/classes
+  - server/discovery/facts
+  - server/discovery/identity
+  - server/registration
   - srvcache
 - name: github.com/choria-io/go-protocol
   version: 72bc3ca9593e692e55a3f5dda61194803f54d619
@@ -88,6 +104,8 @@ imports:
   version: 87033efcaec6215741137e8ca61952c53ef2685d
 - name: github.com/tidwall/match
   version: 1731857f09b1f38450e2c12409748407822dc6be
+- name: github.com/tidwall/sjson
+  version: 6a22caf2fd45d5e2119bfc3717e984f15a7eb7ee
 - name: github.com/xeipuuv/gojsonpointer
   version: 6fe8760cad3569743d51ddbb243b26f8456742dc
 - name: github.com/xeipuuv/gojsonreference

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,3 +18,5 @@ import:
   version: ^0.0.6
 - package: github.com/choria-io/go-validator
   version: ^1.0.2
+- package: github.com/tidwall/sjson
+  version: ^1.0.0

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -26,6 +26,7 @@ var running bool
 func Run(ctx context.Context, wg *sync.WaitGroup, scrapeCfg *config.Config) {
 	defer wg.Done()
 
+	running = true
 	cfg = scrapeCfg
 
 	stream := connection.NewConnection(ctx, scrapeCfg.PollerStream)
@@ -34,8 +35,6 @@ func Run(ctx context.Context, wg *sync.WaitGroup, scrapeCfg *config.Config) {
 		wg.Add(1)
 		go jobWorker(ctx, wg, name, job)
 	}
-
-	running = true
 
 	for {
 		select {


### PR DESCRIPTION
This adjusts the exposed facts to be more usable on the CLI for
fact based discovery, you can easily find all instances for a specific
job or all instances in a specific mode that aren't paused etc

Fact writes are also now triggered as soon as the switch is flipped
so it's always accurate