### PR TITLE
(#17) keep stats about self

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ scrape_interval: 60s
 # the receiver will just delete scrapes thats older than 80 seconds
 max_age: 80
 
+# sets up a prometheus stats listener for /metrics on port 1000
+monitor_port: 10000
+
 # the poller will publish into this NATS Stream
 poller_stream:
   cluster_id: dc1_stream
@@ -127,6 +130,13 @@ jobs:
 I set my Stream to keep 10 minutes of data only for this data everywhere.
 
 Configure Prometheus to consume data from the Push Gateway - here http://prometheus.dc2.example.net:9091/metrics.
+
+Own Metrics
+-----------
+
+When `monitor_port` is set to a value greater than 0 this process will listen for Prometheus requests on `/metrics` on that port.
+
+It will also add itself as a scrape job called `prometheus_streams` and set up a matching target so you do not need to set up a scrape for itself when metrics are enabled.
 
 Management
 ----------

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c9e3fbddac4a20f59c46e56c1eea276e6c3c0e20afe1d5e8bb77b9dc93a66903
-updated: 2018-02-12T18:47:50.424986+01:00
+hash: 3814f054f2f266c09ab0eb0f3553a3ab31e1da385b21474611fd42668eeac175
+updated: 2018-02-14T16:07:57.600696+01:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -76,7 +76,6 @@ imports:
   version: 967789050ba94deca04a5e84cce8ad472ce313c1
   subpackages:
   - prometheus
-  - prometheus/promhttp
 - name: github.com/prometheus/client_model
   version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,3 +20,5 @@ import:
   version: ^1.0.2
 - package: github.com/tidwall/sjson
   version: ^1.0.0
+- package: github.com/prometheus/client_golang
+  version: ^0.9.0-pre1

--- a/puppet/README.md
+++ b/puppet/README.md
@@ -27,37 +27,37 @@ metadata_expire=300
 
 ```puppet
 class{"prometheus_streams":
-    poller => true,
-    receiver => true,
-    poller_stream => {
-        cluster_id => "dc1_stream",
-        urls => "nats://nats.dc1.example.net:4222",
-        topic => "prometheus"
-    },
-    receiver_stream => {
-        client_id => "prometheus_receiver",
-        cluster_id => "global_stream",
-        urls => "nats://nats.dc2.example.net:4222",
-        topic => "prometheus"
-    },
-    push_gateway => {
-        url => "http://prometheus.dc2.example.net:9091"
-    },
-    management => {
-        identity => "prom.example.net",
-        collective => "prometheus",
-        brokers => ["choria.example.net:4222"]
-    },
-    jobs => {
-        "choria" => {
-            "targets" => [
-                {
-                    "name" => "choria1",
-                    "url"=> "http://choria1.dc1.example.net:8222/choria/prometheus"
-                }
-            ]
+  poller => true,
+  receiver => true,
+  poller_stream => {
+    cluster_id => "dc1_stream",
+    urls => "nats://nats.dc1.example.net:4222",
+    topic => "prometheus"
+  },
+  receiver_stream => {
+    client_id => "prometheus_receiver",
+    cluster_id => "global_stream",
+    urls => "nats://nats.dc2.example.net:4222",
+    topic => "prometheus"
+  },
+  push_gateway => {
+    url => "http://prometheus.dc2.example.net:9091"
+  },
+  management => {
+    identity => "prom.example.net",
+    collective => "prometheus",
+    brokers => ["choria.example.net:4222"]
+  },
+  jobs => {
+    "choria" => {
+      "targets" => [
+        {
+          "name" => "choria1",
+          "url"=> "http://choria1.dc1.example.net:8222/choria/prometheus"
         }
+      ]
     }
+  }
 }
 ```
 

--- a/puppet/manifests/config.pp
+++ b/puppet/manifests/config.pp
@@ -3,6 +3,7 @@ class prometheus_streams::config {
         "verbose" => $prometheus_streams::verbose,
         "debug" => $prometheus_streams::debug,
         "logfile" => $prometheus_streams::log_file,
+        "monitor_port" => $prometheus_streams::monitor_port,
         "scrape_interval" => $prometheus_streams::scrape_interval,
         "max_age" => $prometheus_streams::max_age,
         "poller_stream" => $prometheus_streams::poller_stream,

--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -25,6 +25,7 @@
 # @param verbose Enables verbose logging
 # @param scrape_interval Interval to scrape targets
 # @param max_age Maximum age of metrics the receiver will accept
+# @param monitor_port When set enables prometheus metrics on this port
 # @param poller_stream Stream to publish metrics to
 # @param receiver_stream Stream to read metrics from
 # @param push_gateway Push Gateway the Receiver will publish metrics to
@@ -44,6 +45,7 @@ class prometheus_streams (
     Boolean $verbose = false,
     Pattern[/^\d+(m|h|s)$/] $scrape_interval = "30s",
     Integer $max_age = 65,
+    Integer $monitor_port = 0,
     Prometheus_streams::Stream $poller_stream = {},
     Prometheus_streams::Stream $receiver_stream = {},
     Prometheus_streams::Push_gateway $push_gateway = {},

--- a/receiver/stats.go
+++ b/receiver/stats.go
@@ -1,0 +1,52 @@
+package receiver
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	errorCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "prometheus_streams_receiver_publish_errors",
+		Help: "Errors encountered during pushing to PushGateway",
+	}, []string{"receiver_job"})
+
+	agedCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "prometheus_streams_receiver_aged_discards",
+		Help: "Messages that got discarded due to age",
+	}, []string{"receiver_job"})
+
+	msgCtr = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_streams_receiver_received",
+		Help: "Total number of received messages including too old ones",
+	})
+
+	pauseGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_streams_receiver_paused",
+		Help: "Indicates if the receiver is paused",
+	})
+
+	decompressTime = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "prometheus_streams_receiver_decompress_time",
+		Help: "How long it takes to decompress messages",
+	})
+
+	publishTime = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "prometheus_streams_receiver_publish_time",
+		Help: "How long it takes to publish to Push Gateway",
+	})
+
+	instanceSeenTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "prometheus_streams_receiver_seen_time",
+		Help: "When last data for a specific job and instance was received",
+	}, []string{"receiver_job", "receiver_instance"})
+)
+
+func init() {
+	prometheus.MustRegister(errorCtr)
+	prometheus.MustRegister(pauseGauge)
+	prometheus.MustRegister(agedCtr)
+	prometheus.MustRegister(decompressTime)
+	prometheus.MustRegister(publishTime)
+	prometheus.MustRegister(msgCtr)
+	prometheus.MustRegister(instanceSeenTime)
+}

--- a/scrape/scraper.go
+++ b/scrape/scraper.go
@@ -10,12 +10,15 @@ import (
 	"time"
 
 	"github.com/choria-io/prometheus-streams/config"
+	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context/ctxhttp"
 )
 
 func jobWorker(ctx context.Context, wg *sync.WaitGroup, name string, job *config.Job) {
 	defer wg.Done()
+
+	targetGauge.WithLabelValues(name).Set(float64(len(job.Targets)))
 
 	for _, target := range job.Targets {
 		wg.Add(1)
@@ -34,45 +37,67 @@ func targetWorker(ctx context.Context, wg *sync.WaitGroup, jobname string, targe
 
 	client := &http.Client{}
 
+	poll := func() {
+		obs := prometheus.NewTimer(pollTime.WithLabelValues(jobname, target.Name))
+		defer obs.ObserveDuration()
+
+		if paused {
+			return
+		}
+
+		timeout, cancel := context.WithTimeout(ctx, interval)
+		defer cancel()
+
+		log.Debugf("Polling %s @ %s", target.Name, target.URL)
+		resp, err := ctxhttp.Get(timeout, client, target.URL)
+
+		if err != nil {
+			log.Errorf("Could not fetch %s: %s", target.URL, err)
+			pollErrCtr.WithLabelValues(jobname, target.Name).Inc()
+			return
+		}
+
+		if resp == nil {
+			log.Errorf("Could not fetch %s: unknown error", target.URL)
+			pollErrCtr.WithLabelValues(jobname, target.Name).Inc()
+			return
+		}
+
+		if resp.StatusCode >= 300 {
+			log.Errorf("Could not fetch %s: %s", target.URL, resp.Status)
+			pollErrCtr.WithLabelValues(jobname, target.Name).Inc()
+			return
+		}
+
+		body, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			log.Errorf("Could not read body of %s: %s", target.URL, err)
+			pollErrCtr.WithLabelValues(jobname, target.Name).Inc()
+			return
+		}
+
+		pollSizeCtr.WithLabelValues(jobname, target.Name).Add(float64(len(body)))
+
+		cbody, err := compress(body)
+		if err != nil {
+			log.Errorf("Could not compress result for %s: %s", target.URL, err)
+			pollErrCtr.WithLabelValues(jobname, target.Name).Inc()
+			return
+		}
+
+		outbox <- Scrape{
+			Job:       jobname,
+			Instance:  target.Name,
+			Timestamp: time.Now().UTC().Unix(),
+			Scrape:    cbody,
+		}
+	}
+
 	for {
 		select {
 		case <-timer.C:
-			if paused {
-				continue
-			}
-
-			log.Debugf("Polling %s @ %s", target.Name, target.URL)
-			timeout, _ := context.WithTimeout(ctx, interval)
-			resp, err := ctxhttp.Get(timeout, client, target.URL)
-			if err != nil {
-				log.Errorf("Could not fetch %s: %s", target.URL, err)
-				continue
-			}
-
-			if resp.StatusCode >= 300 {
-				log.Errorf("Could not fetch %s: %s", target.URL, resp.Status)
-				continue
-			}
-
-			body, err := ioutil.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil {
-				log.Errorf("Could not read body of %s: %s", target.URL, err)
-				continue
-			}
-
-			cbody, err := compress(body)
-			if err != nil {
-				log.Errorf("Could not compress result for %s: %s", target.URL, err)
-				continue
-			}
-
-			outbox <- Scrape{
-				Job:       jobname,
-				Instance:  target.Name,
-				Timestamp: time.Now().UTC().Unix(),
-				Scrape:    cbody,
-			}
+			poll()
 		case <-ctx.Done():
 			return
 		}
@@ -80,6 +105,9 @@ func targetWorker(ctx context.Context, wg *sync.WaitGroup, jobname string, targe
 }
 
 func compress(data []byte) ([]byte, error) {
+	obs := prometheus.NewTimer(compressTime)
+	defer obs.ObserveDuration()
+
 	var b bytes.Buffer
 
 	gz := gzip.NewWriter(&b)

--- a/scrape/stats.go
+++ b/scrape/stats.go
@@ -1,0 +1,70 @@
+package scrape
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	jobsGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_streams_poller_jobs",
+		Help: "How many jobs are configured",
+	})
+
+	publishedCtr = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_streams_poller_published_count",
+		Help: "How many messages containing scrapes were published",
+	})
+
+	errorCtr = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "prometheus_streams_poller_publish_errors",
+		Help: "Errors encountered during publishes",
+	})
+
+	pollErrCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "prometheus_streams_poller_poll_errors",
+		Help: "Errors encountered during polls",
+	}, []string{"poller_job", "poller_target"})
+
+	publishTime = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "prometheus_streams_poller_publish_time",
+		Help: "How long it took to publish messages to the stream",
+	})
+
+	compressTime = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name: "prometheus_streams_poller_compress_time",
+		Help: "How long it takes to compress messages",
+	})
+
+	pollTime = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Name: "prometheus_streams_poller_poll_time",
+		Help: "How long it takes to poll targets",
+	}, []string{"poller_job", "poller_target"})
+
+	pollSizeCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "prometheus_streams_poller_bytes_polled",
+		Help: "How many bytes were polled from a target",
+	}, []string{"poller_job", "poller_target"})
+
+	pauseGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prometheus_streams_poller_paused",
+		Help: "Indicates if the poller is paused",
+	})
+
+	targetGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "prometheus_streams_poller_targets",
+		Help: "How many targets are configured",
+	}, []string{"poller_job"})
+)
+
+func init() {
+	prometheus.MustRegister(jobsGauge)
+	prometheus.MustRegister(publishedCtr)
+	prometheus.MustRegister(errorCtr)
+	prometheus.MustRegister(pollErrCtr)
+	prometheus.MustRegister(publishTime)
+	prometheus.MustRegister(pauseGauge)
+	prometheus.MustRegister(targetGauge)
+	prometheus.MustRegister(compressTime)
+	prometheus.MustRegister(pollTime)
+	prometheus.MustRegister(pollSizeCtr)
+}


### PR DESCRIPTION
This keeps extensive stats about itself and expose it on /metrics when
monitor_port is set

Additionally when set this will automatically set up a job and scrape target
to publish itself