### PR TITLE
(#20) use hostname for the name of the prometheus_streams job

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -101,7 +101,7 @@ func (cfg *Config) prepare() error {
 	if cfg.MonitorPort > 0 {
 		t := []*Target{}
 		t = append(t, &Target{
-			Name: "prometheus_streams",
+			Name: cfg.Hostname,
 			URL:  fmt.Sprintf("http://localhost:%d/metrics", cfg.MonitorPort),
 		})
 


### PR DESCRIPTION
This will improve the graphs that can be built so individual senders
can be shown - right now its really confusing