### PR TITLE
(#25) have only a poller dimension in the seen time

### DIFF
--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -160,7 +160,7 @@ func handler(msg *stan.Msg) {
 		}
 	}
 
-	instanceSeenTime.WithLabelValues(s.Job, s.Instance, s.Publisher).Set(float64(time.Now().UTC().Unix()))
+	instanceSeenTime.WithLabelValues(s.Publisher).Set(float64(time.Now().UTC().Unix()))
 
 	inbox <- s
 }

--- a/receiver/stats.go
+++ b/receiver/stats.go
@@ -38,7 +38,7 @@ var (
 	instanceSeenTime = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "prometheus_streams_receiver_seen_time",
 		Help: "When last data for a specific job and instance was received",
-	}, []string{"receiver_job", "receiver_instance", "poller"})
+	}, []string{"poller"})
 )
 
 func init() {


### PR DESCRIPTION
There's no real point in tracking the target or instance since the thing
you're trying to figure out is when last the host that is sending sent
anything, so having just the one dimension is best