### PR TITLE
(#49) support SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,42 @@ I set my Stream to keep 10 minutes of data only for this data everywhere.
 
 Configure Prometheus to consume data from the Push Gateway - here http://prometheus.dc2.example.net:9091/metrics.
 
+TLS
+---
+
+TLS is supported on the NATS and management connections, you can configure a single TLS setup for all connections or per connection. For all connections add this to the top of the config, else you can add the exact configuration in the `management`, `receiver_stream` and `poller_stream` sections, this is handy if they have different CAs.
+
+2 modes are supported, Puppet CA compatible or full manual configuration:
+
+### Puppet
+
+In this mode a Puppet compatible SSL setup is required in a specific directory:
+
+```yaml
+tls:
+  identity: prom.example.net
+  ssl_dir: /etc/prometheus-streams/ssl
+  scheme: puppet
+```
+
+If you use this mode you can use the `prometheus-stream enroll prom.example.net --dir /etc/prometheus-streams/ssl prom.example.net` command to go through the process of obtaining a certificate for this instance from the PuppetCA, the process is identical to the `--waitforcert` mode in `puppet agent` and requires you to have a unique certificate identity.
+
+### Manual
+
+This mode is completely configurable:
+
+```yaml
+tls:
+  identity: prom.example.net
+  scheme: manual
+  ca: /path/to/ca.pem
+  cert: /path/to/cert.pem
+  key: /path/to/key.pem
+  cache: /path/to/cert_cache # required if you use the management backend
+```
+
+These `tls` stanzas can be set either at the top level as here - where it will apply to all NATS connections - or on the individual `management`, `receiver_stream` and `poller_stream` level in the event that you need different set ups for these.
+
 Own Metrics
 -----------
 
@@ -190,7 +226,7 @@ metadata_expire=300
 
 ## Puppet Module
 
-A Puppet module to install and manage the Stream Replicator can be found on the Puppet Forge as `choria/prometheus_streams`
+A Puppet module to install and manage the Stream Replicator can be found on the Puppet Forge as [choria/prometheus_streams](https://forge.puppet.com/choria/prometheus_streams)
 
 ## Thanks
 

--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -1,0 +1,56 @@
+package backoff
+
+// https://blog.gopheracademy.com/advent-2014/backoff/
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"time"
+)
+
+// BackoffPolicy implements a backoff policy, randomizing its delays
+// and saturating at the final value in Millis.
+type BackoffPolicy struct {
+	Millis []int
+}
+
+// FiveSec is a backoff policy ranging up to 5 seconds.
+var FiveSec = BackoffPolicy{
+	[]int{500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000},
+}
+
+// Duration returns the time duration of the n'th wait cycle in a
+// backoff policy. This is b.Millis[n], randomized to avoid thundering
+// herds.
+func (b BackoffPolicy) Duration(n int) time.Duration {
+	if n >= len(b.Millis) {
+		n = len(b.Millis) - 1
+	}
+
+	return time.Duration(jitter(b.Millis[n])) * time.Millisecond
+}
+
+// InterruptableSleep sleep for the duration of the n'th wait cycle
+// in a way that can be interrupted by the context.  An error is returned
+// if the context cancels the sleep
+func (b BackoffPolicy) InterruptableSleep(ctx context.Context, n int) error {
+	timer := time.NewTimer(b.Duration(n))
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return errors.New("sleep interrupted by context")
+	}
+}
+
+// jitter returns a random integer uniformly distributed in the range
+// [0.5 * millis .. 1.5 * millis]
+func jitter(millis int) int {
+	if millis == 0 {
+		return 0
+	}
+
+	return millis/2 + rand.Intn(millis)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	PushGateway    *PushGatewayConfig `json:"push_gateway"`
 	Management     *ManagementConfig  `json:"management"`
 
+	TLS *TLSConf `json:"tls"`
+
 	ConfigFile string `json:"-"`
 }
 
@@ -46,10 +48,11 @@ type Target struct {
 
 // StreamConfig is the target to publish data to
 type StreamConfig struct {
-	ClientID  string `json:"client_id"`
-	ClusterID string `json:"cluster_id"`
-	URLs      string `json:"urls"`
-	Topic     string `json:"topic"`
+	ClientID  string   `json:"client_id"`
+	ClusterID string   `json:"cluster_id"`
+	URLs      string   `json:"urls"`
+	Topic     string   `json:"topic"`
+	TLS       *TLSConf `json:"tls"`
 }
 
 // PushGatewayConfig where the receiver will publish metrics to
@@ -63,6 +66,7 @@ type ManagementConfig struct {
 	Brokers    []string `json:"brokers"`
 	Identity   string   `json:"identity"`
 	Collective string   `json:"collective"`
+	TLS        *TLSConf `json:"tls"`
 }
 
 // NewConfig parses a config file into a Config
@@ -131,6 +135,20 @@ func (cfg *Config) prepare() error {
 			if err != nil {
 				return err
 			}
+		}
+
+		if cfg.Management.TLS == nil && cfg.TLS != nil {
+			cfg.Management.TLS = cfg.TLS
+		}
+	}
+
+	if cfg.TLS != nil {
+		if cfg.PollerStream.TLS == nil {
+			cfg.PollerStream.TLS = cfg.TLS
+		}
+
+		if cfg.ReceiverStream.TLS == nil {
+			cfg.ReceiverStream.TLS = cfg.TLS
 		}
 	}
 

--- a/config/tlsconfig.go
+++ b/config/tlsconfig.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"fmt"
+
+	security "github.com/choria-io/go-security"
+	"github.com/choria-io/go-security/filesec"
+	"github.com/choria-io/go-security/puppetsec"
+	"github.com/sirupsen/logrus"
+)
+
+// TLSConf describes the TLS config for a NATS connection
+type TLSConf struct {
+	Identity string `json:"identity"`
+	SSLDir   string `json:"ssl_dir"`
+	Scheme   string `json:"scheme"`
+	CA       string `json:"ca"`
+	Cert     string `json:"cert"`
+	Key      string `json:"key"`
+	Cache    string `json:"cache"`
+}
+
+// SecurityProvider creates a security provider for the given scheme
+func (t *TLSConf) SecurityProvider() (security.Provider, error) {
+	switch t.Scheme {
+	case "puppet":
+		return t.puppetSecurityProvider()
+	case "file", "manual":
+		return t.fileSecurityProvider()
+	default:
+		return nil, fmt.Errorf("unknown security scheme: %s", t.Scheme)
+	}
+}
+
+func (t *TLSConf) puppetSecurityProvider() (security.Provider, error) {
+	c := &puppetsec.Config{
+		SSLDir:   t.SSLDir,
+		Identity: t.Identity,
+	}
+
+	logger := logrus.New()
+
+	return puppetsec.New(puppetsec.WithConfig(c), puppetsec.WithLog(logger.WithFields(logrus.Fields{"security": "puppet"})))
+}
+
+func (t *TLSConf) fileSecurityProvider() (security.Provider, error) {
+	c := &filesec.Config{
+		CA:          t.CA,
+		Certificate: t.Cert,
+		Key:         t.Key,
+		Identity:    t.Identity,
+	}
+
+	logger := logrus.New()
+
+	return filesec.New(filesec.WithConfig(c), filesec.WithLog(logger.WithFields(logrus.Fields{"security": "file"})))
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3814f054f2f266c09ab0eb0f3553a3ab31e1da385b21474611fd42668eeac175
-updated: 2018-02-14T16:07:57.600696+01:00
+hash: 1b1ab9b142570e0e7731e77eff0d80cf66d41e2ef4a60fd736b370f1c3bc3cfc
+updated: 2018-05-30T10:47:15.625856+02:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -8,21 +8,19 @@ imports:
 - name: github.com/alecthomas/units
   version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
 - name: github.com/beorn7/perks
-  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/choria-io/go-choria
-  version: 294656073efe1103bcd8e30d1156347d2177e184
+  version: a3b74b8d7769db8ec227d4cf0a75aaebb28ad2fd
   subpackages:
-  - agents/choriautil
-  - agents/discovery
-  - agents/provision
-  - agents/rpcutil
   - backoff
   - build
   - choria
+  - config
   - mcorpc
   - mcorpc/audit
+  - puppet
   - registration
   - server
   - server/agents
@@ -34,27 +32,44 @@ imports:
   - server/discovery/identity
   - server/registration
   - srvcache
+- name: github.com/choria-io/go-confkey
+  version: 634d2c41860498507b0c7eeb2f8a33b1aa6a809d
 - name: github.com/choria-io/go-protocol
-  version: 72bc3ca9593e692e55a3f5dda61194803f54d619
+  version: b7292acc12958de22c268a49883e565aa667b402
   subpackages:
   - protocol
   - protocol/v1
-- name: github.com/choria-io/go-validator
-  version: 99e0f793dd701e8cf45fd27624390ea43699e3b9
-- name: github.com/choria-io/stream-replicator
-  version: 463aca6922c3118d570c9e226436a9938cf7b9f7
+- name: github.com/choria-io/go-security
+  version: 615ff9a3ca0cabc08289e491ef8f57b6a51031a7
   subpackages:
-  - backoff
+  - filesec
+  - puppetsec
+- name: github.com/choria-io/go-validator
+  version: 4ce2ef25983faa873cc4bcea0f1ef2a4273d42cc
+  subpackages:
+  - duration
+  - enum
+  - ipaddress
+  - ipv4
+  - ipv6
+  - maxlength
+  - regex
+  - shellsafe
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/gogo/protobuf
-  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
+  version: 99cb9b23110011cc45571c901ecae6f6f5e65cd3
   subpackages:
   - gogoproto
   - proto
   - protoc-gen-gogo/descriptor
+- name: github.com/golang/mock
+  version: 8b2eeeb0ca5f56c78bec5efde9c4a21d9201126c
+  subpackages:
+  - gomock
+  - mockgen
 - name: github.com/golang/protobuf
-  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
+  version: df1d3ca07d2d07bba352d5b73c4313b4e2a6203e
   subpackages:
   - proto
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -62,7 +77,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/nats-io/go-nats
-  version: d66cb54e6b7bdd93f0b28afc8450d84c780dfb68
+  version: 062418ea1c2181f52dc0f954f6204370519a868b
   subpackages:
   - encoders/builtin
   - util
@@ -71,61 +86,57 @@ imports:
   subpackages:
   - pb
 - name: github.com/nats-io/nuid
-  version: 33c603157d6fd1b0ac2599bcc4a286b36479a06d
+  version: 28b996b57a46dd0c2aa3a3dc7fa8780878331d00
 - name: github.com/prometheus/client_golang
   version: 967789050ba94deca04a5e84cce8ad472ce313c1
   subpackages:
   - prometheus
+  - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 89604d197083d4781071d3c65855d24ecfb0a563
+  version: 61f87aac8082fa8c3c5655c7608d7478d46ac2ad
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: b15cd069a83443be3154b719d0cc9fe8117f09fb
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
   subpackages:
   - xfs
-- name: github.com/prometheus/prometheus
-  version: 85f23d82a045d103ea7f3c89a91fba4a93e6367a
-  subpackages:
-  - pkg/labels
-  - storage
 - name: github.com/satori/go.uuid
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
-  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
+  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/tidwall/gjson
-  version: 87033efcaec6215741137e8ca61952c53ef2685d
+  version: 01f00f129617a6fe98941fb920d6c760241b54d2
 - name: github.com/tidwall/match
   version: 1731857f09b1f38450e2c12409748407822dc6be
 - name: github.com/tidwall/sjson
   version: 6a22caf2fd45d5e2119bfc3717e984f15a7eb7ee
 - name: github.com/xeipuuv/gojsonpointer
-  version: 6fe8760cad3569743d51ddbb243b26f8456742dc
+  version: 4e3ac2762d5f479393488629ee9370b50873b3a6
 - name: github.com/xeipuuv/gojsonreference
-  version: e02fc20de94c78484cd5ffb007f8af96be030a45
+  version: bd5ef7bd5415a7ac448318e64f11a24cd21e594b
 - name: github.com/xeipuuv/gojsonschema
-  version: 511d08a359d14c0dd9c4302af52ee9abb6f93c2a
+  version: 9ff6d6c47f3f5de55acc6f464d6e3719b02818ae
 - name: golang.org/x/crypto
   version: 9477e0b78b9ac3d0b03822fd95422e2fe07627cd
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
-  version: 5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec
+  version: 89e543239a64caf31d3a6865872ea120b41446df
   subpackages:
   - context
   - context/ctxhttp
 - name: golang.org/x/sys
-  version: e24f485414aeafb646f6fca458b0bf869c0880a1
+  version: f7928cfef4d09d1b080aa2b6fd3ca9ba1567c733
   subpackages:
   - unix
 - name: gopkg.in/alecthomas/kingpin.v2
   version: 947dcec5ba9c011838740e680966fd7087a71d0d
 - name: gopkg.in/yaml.v2
-  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,24 +1,34 @@
 package: github.com/choria-io/prometheus-streams
 import:
-- package: github.com/choria-io/stream-replicator
-  subpackages:
-  - backoff
-- package: github.com/nats-io/go-nats
-- package: github.com/nats-io/go-nats-streaming
-- package: github.com/prometheus/prometheus
-  subpackages:
-  - pkg/labels
-  - storage
-- package: github.com/sirupsen/logrus
-- package: github.com/ghodss/yaml
-- package: github.com/satori/go.uuid
-- package: gopkg.in/alecthomas/kingpin.v2
-  version: ^2.2.6
 - package: github.com/choria-io/go-choria
-  version: ^0.0.6
-- package: github.com/choria-io/go-validator
-  version: ^1.0.2
-- package: github.com/tidwall/sjson
-  version: ^1.0.0
+  subpackages:
+  - choria
+  - mcorpc
+  - server
+  - server/agents
+- package: github.com/choria-io/go-security
+  version: ^0.0.2
+  subpackages:
+  - filesec
+  - puppetsec
+- package: github.com/ghodss/yaml
+  version: ^1
+- package: github.com/nats-io/go-nats
+  version: ^1
+- package: github.com/nats-io/go-nats-streaming
+  version: ^0
 - package: github.com/prometheus/client_golang
-  version: ^0.9.0-pre1
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- package: github.com/satori/go.uuid
+  version: ^1.2.0
+- package: github.com/sirupsen/logrus
+  version: ^1
+- package: github.com/tidwall/sjson
+  version: ^1
+- package: golang.org/x/net
+  subpackages:
+  - context/ctxhttp
+- package: gopkg.in/alecthomas/kingpin.v2
+  version: ^2

--- a/management/facts/facts.go
+++ b/management/facts/facts.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/choria-io/go-choria/choria"
+	choriaconf "github.com/choria-io/go-choria/config"
 	"github.com/choria-io/prometheus-streams/build"
 	"github.com/choria-io/prometheus-streams/config"
 	"github.com/choria-io/prometheus-streams/receiver"
@@ -20,7 +20,7 @@ import (
 )
 
 var f *os.File
-var cconf *choria.Config
+var cconf *choriaconf.Config
 var sconf *config.Config
 var err error
 var mu = &sync.Mutex{}
@@ -39,7 +39,7 @@ func Configure(c *config.Config) {
 	sconf = c
 }
 
-func Expose(ctx context.Context, wg *sync.WaitGroup, cfg *choria.Config) {
+func Expose(ctx context.Context, wg *sync.WaitGroup, cfg *choriaconf.Config) {
 	defer wg.Done()
 
 	cconf = cfg

--- a/puppet/README.md
+++ b/puppet/README.md
@@ -63,3 +63,44 @@ class{"prometheus_streams":
 ```
 
 Full reference about the available options for configuring topics can be found in the project documentation.
+
+### TLS
+
+As of version 0.2.0 of the `prometheus-streams` package TLS is supported for all NATS connections and can be configured using this module.
+
+While this module support configuring TLS properties such as paths to certificates it cannot create the certificate for you, you have to arrange another means of delivering the SSL keys, certificates etc to the host - perhaps in your profile class.
+
+If you use the Puppet scheme you can configure it as below and use the `prometheus-streams enroll` command to create the SSL files:
+
+```puppet
+class{"prometheus_streams":
+  tls                     => {
+    "identity"            => $facts["fqdn"],
+    "scheme"              => "puppet",
+    "ssl_dir"             => "/etc/stream-replicator/ssl"
+  },
+  jobs                    => {
+    # as above
+  }
+}
+```
+
+If you have another CA you can configure it manually, the `cache` is used by the management interface only:
+
+```puppet
+class{"prometheus_streams":
+  tls                     => {
+    "identity"            => $facts["fqdn"],
+    "scheme"              => "manual",
+    "ca"                  => "/path/to/ca.pem",
+    "cert"                => "/path/to/cert.pem",
+    "key"                 => "/path/to/key.pem",
+    "cache"               => "/path/to/cache"
+  },
+  jobs                    => {
+    # as above
+  }
+}
+```
+
+These `tls` stanzas can be set either at the top level as here - where it will apply to all NATS connections - or on the individual `management`, `receiver_stream` and `poller_stream` level in the event that you need different set ups for these.

--- a/puppet/manifests/config.pp
+++ b/puppet/manifests/config.pp
@@ -14,13 +14,19 @@ class prometheus_streams::config {
     }
 
     if !$prometheus_streams::management.empty {
-        $config = $base_config + {"management" => $prometheus_streams::management}
+        $mconfig = $base_config + {"management" => $prometheus_streams::management}
     } else {
-        $config = $base_config
+        $mconfig = $base_config
+    }
+
+    if $prometheus_streams::tls {
+        $config = $mconfig + {"tls" => $prometheus_streams::tls}
+    } else {
+        $config = $mconfig
     }
 
     file{$prometheus_streams::config_file:
-        ensure => $prometheus_streams::ensure,
+        ensure  => $prometheus_streams::ensure,
         content => to_yaml($config)
     }
 }

--- a/puppet/manifests/init.pp
+++ b/puppet/manifests/init.pp
@@ -31,6 +31,7 @@
 # @param receiver_stream Stream to read metrics from
 # @param push_gateway Push Gateway the Receiver will publish metrics to
 # @param management Configuration for the embedded Choria based management interface
+# @param tls System wide TLS configuration, when set applies to management and streams that do not have their own TLS configuration
 # @param jobs Targets to poll
 # @param poller_service_name The name of the Poller service
 # @param receiver_service_name The name of the Receiver service
@@ -52,6 +53,7 @@ class prometheus_streams (
     Variant[Prometheus_streams::Stream, Hash[0, 0]] $receiver_stream = {},
     Variant[Prometheus_streams::Push_gateway, Hash[0, 0]] $push_gateway = {},
     Variant[Prometheus_streams::Management, Hash[0, 0]] $management = {},
+    Optional[Variant[Prometheus_streams::FileSSL, Prometheus_streams::PuppetSSL]] $tls = undef,
     Hash[String, Prometheus_streams::Job] $jobs = {},
     String $poller_service_name = "prometheus-streams-poller",
     String $receiver_service_name = "prometheus-streams-receiver",

--- a/puppet/types/filessl.pp
+++ b/puppet/types/filessl.pp
@@ -1,0 +1,7 @@
+type Prometheus_streams::FileSSL = Struct[{
+  identity => String,
+  scheme => Enum["file", "manual"],
+  ca => Stdlib::Unixpath,
+  cert => Stdlib::Unixpath,
+  key => Stdlib::Unixpath
+}]

--- a/puppet/types/management.pp
+++ b/puppet/types/management.pp
@@ -1,5 +1,6 @@
 type Prometheus_streams::Management = Struct[{
     brokers => Array[String],
     identity => Optional[String],
-    collective => Optional[String]
+    collective => Optional[String],
+    tls => Optional[Variant[Prometheus_streams::FileSSL, Prometheus_streams::PuppetSSL]]
 }]

--- a/puppet/types/puppetssl.pp
+++ b/puppet/types/puppetssl.pp
@@ -1,0 +1,5 @@
+type Prometheus_streams::PuppetSSL = Struct[{
+  identity => String,
+  scheme => Enum["puppet"],
+  ssl_dir => Stdlib::Unixpath
+}]

--- a/puppet/types/stream.pp
+++ b/puppet/types/stream.pp
@@ -2,5 +2,6 @@ type Prometheus_streams::Stream = Struct[{
     client_id => Optional[String],
     cluster_id => String,
     urls => String,
-    topic => String
+    topic => String,
+    tls => Optional[Variant[Prometheus_streams::FileSSL, Prometheus_streams::PuppetSSL]]
 }]

--- a/receiver/receiver.go
+++ b/receiver/receiver.go
@@ -26,6 +26,7 @@ var inbox = make(chan scrape.Scrape, 10)
 var maxAge int64
 var paused bool
 var running bool
+var err error
 
 func Run(ctx context.Context, wg *sync.WaitGroup, cfg *config.Config) {
 	defer wg.Done()
@@ -33,10 +34,15 @@ func Run(ctx context.Context, wg *sync.WaitGroup, cfg *config.Config) {
 	running = true
 	maxAge = cfg.MaxAge
 
-	conn := connection.NewConnection(ctx, cfg.ReceiverStream)
+	conn, err := connection.NewConnection(ctx, cfg.ReceiverStream)
+	if err != nil {
+		log.Errorf("Could not set up middleware connection: %s", err)
+		return
+	}
 
 	// timed out, ctx cancelled etc, anyway, its dead, nothing can be done
 	if conn.Conn == nil {
+		log.Errorf("Could not set up middleware connection, perhaps due to interrupt")
 		return
 	}
 

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -27,6 +27,7 @@ var paused bool
 var running bool
 var stream *connection.Connection
 var hostname string
+var err error
 
 func Run(ctx context.Context, wg *sync.WaitGroup, scrapeCfg *config.Config) {
 	defer wg.Done()
@@ -36,7 +37,11 @@ func Run(ctx context.Context, wg *sync.WaitGroup, scrapeCfg *config.Config) {
 	running = true
 	cfg = scrapeCfg
 
-	stream = connection.NewConnection(ctx, scrapeCfg.PollerStream)
+	stream, err = connection.NewConnection(ctx, scrapeCfg.PollerStream)
+	if err != nil {
+		log.Errorf("Could not start scrape: %s", err)
+		return
+	}
 
 	jobsGauge.Set(float64(len(cfg.Jobs)))
 	pauseGauge.Set(0)


### PR DESCRIPTION
This uses the go-security project to support puppet and file security
modes.  There is a new command 'enroll' that can help with initial setup
of the SSL files, the puppet module have been modified accordingly